### PR TITLE
feat: IPv4/IPv6関連バリデーション追加・修正＆Phpstanエラー解消

### DIFF
--- a/src/main/php/Sflf/Form.php
+++ b/src/main/php/Sflf/Form.php
@@ -174,7 +174,7 @@
  * @see https://github.com/rain-noise/sflf/blob/master/src/main/php/extensions/smarty/plugins/block.unless_errors.php エラー有無分岐用 Smarty タグ
  *
  * @package   SFLF
- * @version   v4.0.3
+ * @version   v4.0.4
  * @author    github.com/rain-noise
  * @copyright Copyright (c) 2017 github.com/rain-noise
  * @license   MIT License https://github.com/rain-noise/sflf/blob/master/LICENSE
@@ -2007,6 +2007,9 @@ abstract class Form
 
     /**
      * IPv4(CIDR)アドレスリスト（デフォルト区切り：改行)
+     * ※`#`以降の文字列はコメントとして無視されます。
+     * ※余分な空白はトリムされます。
+     * ※空行は無視されます。
      *
      * @param string           $field     検査対象フィールド名
      * @param string           $label     検査対象フィールドのラベル名
@@ -2022,7 +2025,7 @@ abstract class Form
         assert(!is_null($value));
         $errors = [];
         foreach (explode($delimiter, $value) as $i => $ip) {
-            $ip = trim($ip);
+            $ip = trim(preg_replace('/#.*$/','',$ip) ?? '');
             if (!empty($ip) && !preg_match(self::IP_V4_PATTERN, $ip)) {
                 $errors[] = ($i + 1)." 行目の{$label} [ {$ip} ] はIPアドレス(CIDR)形式で入力して下さい。";
             }

--- a/src/main/php/Sflf/Form.php
+++ b/src/main/php/Sflf/Form.php
@@ -174,7 +174,7 @@
  * @see https://github.com/rain-noise/sflf/blob/master/src/main/php/extensions/smarty/plugins/block.unless_errors.php エラー有無分岐用 Smarty タグ
  *
  * @package   SFLF
- * @version   v4.0.5
+ * @version   v4.0.6
  * @author    github.com/rain-noise
  * @copyright Copyright (c) 2017 github.com/rain-noise
  * @license   MIT License https://github.com/rain-noise/sflf/blob/master/LICENSE
@@ -2389,7 +2389,7 @@ abstract class Form
             return [];
         }
         $org  = $text;
-        $conv = mb_convert_encoding(mb_convert_encoding($text, $encode, 'UTF-8'), 'UTF-8', $encode);
+        $conv = mb_convert_encoding(mb_convert_encoding($text, $encode, 'UTF-8') ?: '', 'UTF-8', $encode) ?: '';
         if (strlen($org) != strlen($conv)) {
             $diff = array_diff(preg_split("//u", $org, -1, PREG_SPLIT_NO_EMPTY) ?: [], preg_split("//u", $conv, -1, PREG_SPLIT_NO_EMPTY) ?: []);
             return $diff;

--- a/src/main/php/Sflf/Util.php
+++ b/src/main/php/Sflf/Util.php
@@ -17,7 +17,7 @@
  * $pass = Util::randomCode(8);
  *
  * @package   SFLF
- * @version   v4.1.1
+ * @version   v4.1.2
  * @author    github.com/rain-noise
  * @copyright Copyright (c) 2017 github.com/rain-noise
  * @license   MIT License https://github.com/rain-noise/sflf/blob/master/LICENSE
@@ -655,7 +655,7 @@ class Util
             return [];
         }
         $org  = $text;
-        $conv = mb_convert_encoding(mb_convert_encoding($text, $encode, 'UTF-8'), 'UTF-8', $encode);
+        $conv = mb_convert_encoding(mb_convert_encoding($text, $encode, 'UTF-8') ?: '', 'UTF-8', $encode) ?: '';
         if (strlen($org) != strlen($conv)) {
             $diff = array_diff(self::stringToArray($org), self::stringToArray($conv));
             return $diff;
@@ -1234,7 +1234,7 @@ class Util
             $line .= '"'.str_replace('"', '""', $val ?? '').'",';
         }
         $line = substr($line, 0, -1);
-        fwrite($stream, mb_convert_encoding($line, $encoding, "UTF-8"));
+        fwrite($stream, mb_convert_encoding($line, $encoding, "UTF-8") ?: '');
     }
 
     /**
@@ -1261,7 +1261,7 @@ class Util
             $line .= '"'.str_replace('"', '""', $val ?? '').'",';
         }
         $line = substr($line, 0, -1);
-        fwrite($stream, mb_convert_encoding($line, $encoding, "UTF-8"));
+        fwrite($stream, mb_convert_encoding($line, $encoding, "UTF-8") ?: '');
     }
 
     /**
@@ -1282,7 +1282,7 @@ class Util
             $line .= '"'.str_replace('"', '""', $val ?? '').'",';
         }
         $line = substr($line, 0, -1);
-        fwrite($stream, mb_convert_encoding($line, $encoding, "UTF-8"));
+        fwrite($stream, mb_convert_encoding($line, $encoding, "UTF-8") ?: '');
     }
 
     /**


### PR DESCRIPTION
以下の対応を実施。

* feat: Form：IPv4(CIDR)アドレスリストで#で始まるコメントを記載できるようにする
* feat: Form：IPv6(CIDR)系バリデーションを追加
* fix: Phpstan エラー対応